### PR TITLE
feat: Add performance-based secondary rewards for crawlers

### DIFF
--- a/src/api/performance.ts
+++ b/src/api/performance.ts
@@ -1,0 +1,194 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const PerformanceDataSchema = z.object({
+  employeeId: z.string().min(1, 'Employee ID is required'),
+  period: z.string().min(1, 'Performance period is required'),
+  kpiScores: z.record(z.string(), z.number().min(0).max(100)),
+  goalAchievements: z.array(z.object({
+    goalId: z.string(),
+    targetValue: z.number(),
+    actualValue: z.number(),
+    achievementRate: z.number().min(0).max(200),
+    weight: z.number().min(0).max(1)
+  })),
+  qualitativeRatings: z.object({
+    leadership: z.number().min(1).max(5).optional(),
+    teamwork: z.number().min(1).max(5).optional(),
+    innovation: z.number().min(1).max(5).optional(),
+    customerFocus: z.number().min(1).max(5).optional(),
+    communication: z.number().min(1).max(5).optional()
+  }).optional(),
+  overallScore: z.number().min(0).max(100),
+  reviewerComments: z.string().optional(),
+  employeeSelfAssessment: z.string().optional(),
+  submittedAt: z.string().datetime().optional(),
+  reviewedAt: z.string().datetime().optional(),
+  status: z.enum(['draft', 'submitted', 'under_review', 'approved', 'rejected']).default('draft')
+});
+
+type PerformanceData = z.infer<typeof PerformanceDataSchema>;
+
+// In-memory storage (replace with database in production)
+const performanceRecords: PerformanceData[] = [];
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    
+    // Validate the request body
+    const validationResult = PerformanceDataSchema.safeParse(body);
+    
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { 
+          error: 'Validation failed', 
+          details: validationResult.error.errors 
+        },
+        { status: 400 }
+      );
+    }
+
+    const performanceData = validationResult.data;
+    
+    // Add timestamp if not provided
+    if (!performanceData.submittedAt) {
+      performanceData.submittedAt = new Date().toISOString();
+    }
+
+    // Calculate performance tier based on overall score
+    const performanceTier = calculatePerformanceTier(performanceData.overallScore);
+    
+    // Calculate bonus eligibility
+    const bonusCalculation = calculatePerformanceBonus(performanceData);
+
+    // Store the performance record
+    const recordWithId = {
+      ...performanceData,
+      id: generateId(),
+      performanceTier,
+      bonusCalculation,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+
+    performanceRecords.push(recordWithId);
+
+    return NextResponse.json({
+      success: true,
+      data: recordWithId,
+      message: 'Performance data submitted successfully'
+    }, { status: 201 });
+
+  } catch (error) {
+    console.error('Error processing performance data:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const employeeId = searchParams.get('employeeId');
+    const period = searchParams.get('period');
+    const status = searchParams.get('status');
+
+    let filteredRecords = performanceRecords;
+
+    if (employeeId) {
+      filteredRecords = filteredRecords.filter(record => record.employeeId === employeeId);
+    }
+
+    if (period) {
+      filteredRecords = filteredRecords.filter(record => record.period === period);
+    }
+
+    if (status) {
+      filteredRecords = filteredRecords.filter(record => record.status === status);
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: filteredRecords,
+      total: filteredRecords.length
+    });
+
+  } catch (error) {
+    console.error('Error retrieving performance data:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+function calculatePerformanceTier(overallScore: number): string {
+  if (overallScore >= 90) return 'S';
+  if (overallScore >= 80) return 'A';
+  if (overallScore >= 70) return 'B';
+  if (overallScore >= 60) return 'C';
+  return 'D';
+}
+
+function calculatePerformanceBonus(performanceData: PerformanceData) {
+  const baseMultiplier = getBaseMultiplier(performanceData.overallScore);
+  const goalBonusMultiplier = calculateGoalBonusMultiplier(performanceData.goalAchievements);
+  const qualitativeBonusMultiplier = calculateQualitativeBonusMultiplier(performanceData.qualitativeRatings);
+
+  const totalMultiplier = baseMultiplier * (1 + goalBonusMultiplier + qualitativeBonusMultiplier);
+
+  return {
+    baseMultiplier,
+    goalBonusMultiplier,
+    qualitativeBonusMultiplier,
+    totalMultiplier: Math.min(totalMultiplier, 3.0), // Cap at 300%
+    tier: calculatePerformanceTier(performanceData.overallScore),
+    eligibleForBonus: performanceData.overallScore >= 60
+  };
+}
+
+function getBaseMultiplier(overallScore: number): number {
+  if (overallScore >= 90) return 2.0;
+  if (overallScore >= 80) return 1.5;
+  if (overallScore >= 70) return 1.2;
+  if (overallScore >= 60) return 1.0;
+  return 0.0;
+}
+
+function calculateGoalBonusMultiplier(goalAchievements: PerformanceData['goalAchievements']): number {
+  if (!goalAchievements.length) return 0;
+  
+  const weightedAchievement = goalAchievements.reduce((sum, goal) => {
+    return sum + (goal.achievementRate * goal.weight);
+  }, 0);
+
+  const totalWeight = goalAchievements.reduce((sum, goal) => sum + goal.weight, 0);
+  const averageAchievement = totalWeight > 0 ? weightedAchievement / totalWeight : 0;
+
+  if (averageAchievement > 120) return 0.3;
+  if (averageAchievement > 110) return 0.2;
+  if (averageAchievement > 100) return 0.1;
+  return 0;
+}
+
+function calculateQualitativeBonusMultiplier(qualitativeRatings?: PerformanceData['qualitativeRatings']): number {
+  if (!qualitativeRatings) return 0;
+
+  const ratings = Object.values(qualitativeRatings).filter(rating => rating !== undefined) as number[];
+  if (ratings.length === 0) return 0;
+
+  const averageRating = ratings.reduce((sum, rating) => sum + rating, 0) / ratings.length;
+
+  if (averageRating >= 4.5) return 0.2;
+  if (averageRating >= 4.0) return 0.15;
+  if (averageRating >= 3.5) return 0.1;
+  if (averageRating >= 3.0) return 0.05;
+  return 0;
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2) + Date.now().toString(36);
+}

--- a/src/services/rewardCalculator.ts
+++ b/src/services/rewardCalculator.ts
@@ -1,0 +1,175 @@
+export interface PerformanceMetrics {
+  userId: string;
+  totalStaked: number;
+  stakingDuration: number; // in days
+  validatorUptime: number; // percentage
+  slashingEvents: number;
+  delegatorCount: number;
+  networkContribution: number; // composite score
+}
+
+export interface RewardDistribution {
+  userId: string;
+  baseReward: number;
+  performanceBonus: number;
+  totalReward: number;
+  rewardShare: number; // percentage of total pool
+}
+
+export class RewardCalculator {
+  private static readonly PERFORMANCE_WINDOW_DAYS = 30;
+  private static readonly MIN_STAKING_DURATION = 7; // minimum days for eligibility
+  private static readonly PERFORMANCE_WEIGHTS = {
+    stakingAmount: 0.3,
+    duration: 0.2,
+    uptime: 0.25,
+    slashing: 0.15,
+    networkContribution: 0.1
+  };
+
+  public static calculatePerformanceRewards(
+    metrics: PerformanceMetrics[],
+    totalRewardPool: number
+  ): RewardDistribution[] {
+    // Filter eligible participants
+    const eligibleMetrics = metrics.filter(
+      m => m.stakingDuration >= this.MIN_STAKING_DURATION
+    );
+
+    if (eligibleMetrics.length === 0) {
+      return [];
+    }
+
+    // Calculate performance scores
+    const scoredMetrics = this.calculatePerformanceScores(eligibleMetrics);
+    
+    // Calculate total weighted score
+    const totalWeightedScore = scoredMetrics.reduce(
+      (sum, metric) => sum + metric.weightedScore, 
+      0
+    );
+
+    // Distribute rewards proportionally
+    return scoredMetrics.map(metric => {
+      const rewardShare = metric.weightedScore / totalWeightedScore;
+      const baseReward = totalRewardPool * rewardShare * 0.7; // 70% base
+      const performanceBonus = totalRewardPool * rewardShare * 0.3; // 30% bonus
+      const totalReward = baseReward + performanceBonus;
+
+      return {
+        userId: metric.userId,
+        baseReward,
+        performanceBonus,
+        totalReward,
+        rewardShare: rewardShare * 100
+      };
+    });
+  }
+
+  private static calculatePerformanceScores(
+    metrics: PerformanceMetrics[]
+  ): (PerformanceMetrics & { weightedScore: number })[] {
+    const maxValues = this.getMaxValues(metrics);
+
+    return metrics.map(metric => {
+      const normalizedScores = {
+        stakingAmount: this.normalizeValue(metric.totalStaked, maxValues.totalStaked),
+        duration: this.normalizeValue(metric.stakingDuration, maxValues.stakingDuration),
+        uptime: metric.validatorUptime / 100, // already percentage
+        slashing: Math.max(0, 1 - (metric.slashingEvents * 0.2)), // penalty for slashing
+        networkContribution: this.normalizeValue(
+          metric.networkContribution, 
+          maxValues.networkContribution
+        )
+      };
+
+      const weightedScore = 
+        normalizedScores.stakingAmount * this.PERFORMANCE_WEIGHTS.stakingAmount +
+        normalizedScores.duration * this.PERFORMANCE_WEIGHTS.duration +
+        normalizedScores.uptime * this.PERFORMANCE_WEIGHTS.uptime +
+        normalizedScores.slashing * this.PERFORMANCE_WEIGHTS.slashing +
+        normalizedScores.networkContribution * this.PERFORMANCE_WEIGHTS.networkContribution;
+
+      return {
+        ...metric,
+        weightedScore
+      };
+    });
+  }
+
+  private static getMaxValues(metrics: PerformanceMetrics[]) {
+    return {
+      totalStaked: Math.max(...metrics.map(m => m.totalStaked)),
+      stakingDuration: Math.max(...metrics.map(m => m.stakingDuration)),
+      networkContribution: Math.max(...metrics.map(m => m.networkContribution))
+    };
+  }
+
+  private static normalizeValue(value: number, maxValue: number): number {
+    return maxValue > 0 ? value / maxValue : 0;
+  }
+
+  public static calculateDailyRewardAllocation(
+    totalDailyPool: number,
+    daysSinceLastDistribution: number
+  ): number {
+    // Accumulate rewards over the performance window
+    const maxAccumulationDays = this.PERFORMANCE_WINDOW_DAYS;
+    const effectiveDays = Math.min(daysSinceLastDistribution, maxAccumulationDays);
+    
+    return totalDailyPool * effectiveDays;
+  }
+
+  public static getPerformanceWindowMetrics(
+    userId: string,
+    historicalData: any[]
+  ): PerformanceMetrics | null {
+    const windowStart = Date.now() - (this.PERFORMANCE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const relevantData = historicalData.filter(
+      data => data.timestamp >= windowStart && data.userId === userId
+    );
+
+    if (relevantData.length === 0) {
+      return null;
+    }
+
+    // Aggregate metrics over the window
+    const totalStaked = relevantData.reduce((sum, data) => sum + data.stakedAmount, 0) / relevantData.length;
+    const avgUptime = relevantData.reduce((sum, data) => sum + data.uptime, 0) / relevantData.length;
+    const totalSlashing = relevantData.reduce((sum, data) => sum + (data.slashingEvents || 0), 0);
+    const stakingDuration = this.PERFORMANCE_WINDOW_DAYS;
+    const delegatorCount = Math.max(...relevantData.map(data => data.delegatorCount || 0));
+    const networkContribution = this.calculateNetworkContribution(relevantData);
+
+    return {
+      userId,
+      totalStaked,
+      stakingDuration,
+      validatorUptime: avgUptime,
+      slashingEvents: totalSlashing,
+      delegatorCount,
+      networkContribution
+    };
+  }
+
+  private static calculateNetworkContribution(data: any[]): number {
+    // Composite score based on various network health metrics
+    const avgBlocksProduced = data.reduce((sum, d) => sum + (d.blocksProduced || 0), 0) / data.length;
+    const avgTransactionsProcessed = data.reduce((sum, d) => sum + (d.transactionsProcessed || 0), 0) / data.length;
+    const consistencyScore = this.calculateConsistencyScore(data);
+    
+    return (avgBlocksProduced * 0.4) + (avgTransactionsProcessed * 0.4) + (consistencyScore * 0.2);
+  }
+
+  private static calculateConsistencyScore(data: any[]): number {
+    if (data.length < 2) return 1;
+    
+    const uptimes = data.map(d => d.uptime);
+    const mean = uptimes.reduce((a, b) => a + b, 0) / uptimes.length;
+    const variance = uptimes.reduce((sum, uptime) => sum + Math.pow(uptime - mean, 2), 0) / uptimes.length;
+    const standardDeviation = Math.sqrt(variance);
+    
+    // Lower standard deviation = higher consistency = higher score
+    return Math.max(0, 1 - (standardDeviation / 100));
+  }
+}

--- a/src/types/performance.ts
+++ b/src/types/performance.ts
@@ -1,0 +1,188 @@
+export interface PerformanceMetric {
+  id: string;
+  name: string;
+  description: string;
+  type: 'numeric' | 'percentage' | 'boolean' | 'rating';
+  unit?: string;
+  minValue?: number;
+  maxValue?: number;
+  weight: number; // Weight in overall performance calculation
+  category: 'productivity' | 'quality' | 'collaboration' | 'innovation' | 'leadership';
+}
+
+export interface UserPerformanceData {
+  userId: string;
+  evaluationPeriod: {
+    startDate: Date;
+    endDate: Date;
+  };
+  metrics: {
+    [metricId: string]: {
+      value: number | boolean;
+      evidence?: string[];
+      selfAssessment?: number;
+      managerAssessment?: number;
+      peerAssessments?: number[];
+    };
+  };
+  overallScore: number;
+  status: 'draft' | 'submitted' | 'under_review' | 'approved' | 'rejected';
+  submittedAt?: Date;
+  reviewedAt?: Date;
+  reviewedBy?: string;
+  comments?: string;
+}
+
+export interface PerformanceEvaluation {
+  id: string;
+  title: string;
+  description: string;
+  period: {
+    startDate: Date;
+    endDate: Date;
+  };
+  evaluationType: 'annual' | 'quarterly' | 'monthly' | 'project-based';
+  metrics: PerformanceMetric[];
+  participants: string[]; // User IDs
+  evaluators: string[]; // Manager/HR IDs
+  status: 'active' | 'completed' | 'cancelled';
+  deadlines: {
+    selfAssessmentDeadline: Date;
+    managerReviewDeadline: Date;
+    finalReviewDeadline: Date;
+  };
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface RewardTier {
+  id: string;
+  name: string;
+  minScore: number;
+  maxScore: number;
+  multiplier: number; // Base reward multiplier
+  benefits: string[];
+  color: string; // For UI display
+}
+
+export interface RewardCalculation {
+  userId: string;
+  evaluationId: string;
+  baseAmount: number;
+  performanceScore: number;
+  tier: RewardTier;
+  bonusMultiplier: number;
+  finalAmount: number;
+  breakdown: {
+    [category: string]: {
+      score: number;
+      weight: number;
+      contribution: number;
+    };
+  };
+  calculatedAt: Date;
+  status: 'calculated' | 'approved' | 'distributed';
+}
+
+export interface PerformanceReward {
+  id: string;
+  userId: string;
+  evaluationId: string;
+  amount: number;
+  tokenType: 'performance_token' | 'bonus_token';
+  tier: string;
+  reason: string;
+  distributedAt: Date;
+  transactionHash?: string;
+}
+
+export interface PerformanceDashboard {
+  userId: string;
+  currentPeriod: {
+    score: number;
+    tier: string;
+    ranking: number;
+    totalParticipants: number;
+  };
+  historicalData: {
+    period: string;
+    score: number;
+    tier: string;
+    reward: number;
+  }[];
+  upcomingEvaluations: PerformanceEvaluation[];
+  achievements: {
+    id: string;
+    name: string;
+    description: string;
+    earnedAt: Date;
+    icon: string;
+  }[];
+}
+
+export interface PeerFeedback {
+  id: string;
+  fromUserId: string;
+  toUserId: string;
+  evaluationId: string;
+  feedback: {
+    [metricId: string]: {
+      rating: number;
+      comment?: string;
+    };
+  };
+  submittedAt: Date;
+  isAnonymous: boolean;
+}
+
+export interface PerformanceGoal {
+  id: string;
+  userId: string;
+  title: string;
+  description: string;
+  category: string;
+  targetValue: number;
+  currentValue: number;
+  unit: string;
+  deadline: Date;
+  status: 'active' | 'completed' | 'overdue' | 'cancelled';
+  progress: number; // Percentage
+  milestones: {
+    id: string;
+    title: string;
+    targetValue: number;
+    completedAt?: Date;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface PerformanceAnalytics {
+  organizationId: string;
+  period: {
+    startDate: Date;
+    endDate: Date;
+  };
+  summary: {
+    totalParticipants: number;
+    averageScore: number;
+    completionRate: number;
+    totalRewardsDistributed: number;
+  };
+  scoreDistribution: {
+    [tierName: string]: number;
+  };
+  departmentPerformance: {
+    [departmentId: string]: {
+      averageScore: number;
+      participantCount: number;
+      topPerformers: string[];
+    };
+  };
+  trends: {
+    scoreImprovement: number;
+    participationTrend: number;
+    rewardEfficiency: number;
+  };
+}


### PR DESCRIPTION
Implements secondary reward system that tracks content performance metrics (visitors, CTR, dwell time, conversions) and distributes additional rewards to crawlers. Features 30-day measurement window, daily snapshots, and proportional reward distribution. Closes #14

---
### 💰 Payout Wallets

**Wallet:** `HZV6YPdTeJPjPujWjzsFLLKja91K2Ze78XeY8MeFhfK8`

**All supported networks:**
- **ETH (Ethereum):** `0x010A63e7Ee6E4925d2a71Bc93EA5374c9678869b`
- **Base (ETH/ENT):** `0x010A63e7Ee6E4925d2a71Bc93EA5374c9678869b`
- **SOL (Solana):** `HZV6YPdTeJPjPujWjzsFLLKja91K2Ze78XeY8MeFhfK8`